### PR TITLE
One()/Next() : Unable to detect empty results

### DIFF
--- a/basic_test.go
+++ b/basic_test.go
@@ -208,7 +208,7 @@ var testGroups = map[string][]ExpectPair{
 		{Expr(1), 1},
 		{Expr(true), true},
 		{Expr("bob"), "bob"},
-		{Expr(nil), nil},
+		{Expr(nil), ErrorResponse{}},
 	},
 	"arith": {
 		{Expr(1).Add(2), 3},

--- a/datum.go
+++ b/datum.go
@@ -88,6 +88,10 @@ func datumUnmarshal(datum *p.Datum, v interface{}) error {
 	return json.Unmarshal(data, v)
 }
 
+func isNullDatum(datum *p.Datum) bool {
+	return datum.GetType() == p.Datum_R_NULL
+}
+
 func datumToJson(datum *p.Datum) ([]byte, error) {
 	switch datum.GetType() {
 	case p.Datum_R_NULL:

--- a/error.go
+++ b/error.go
@@ -84,3 +84,11 @@ type ErrWrongResponseType struct {
 func (e ErrWrongResponseType) Error() string {
 	return "rethinkdb: Wrong response type, you may have used the wrong one of: .Exec(), .One(), .All()"
 }
+
+// ErrNullResult is returned when .One returns nil
+type ErrNullResult struct {
+}
+
+func (e ErrNullResult) Error() string {
+	return "rethinkdb: Not found"
+}

--- a/rows.go
+++ b/rows.go
@@ -115,6 +115,10 @@ func (rows *Rows) Next() bool {
 		rows.buffer = rows.buffer[1:len(rows.buffer)]
 	}
 
+	if isNullDatum(rows.current) {
+		return false
+	}
+
 	return true
 }
 
@@ -125,6 +129,9 @@ func (rows *Rows) Next() bool {
 // before writing the next row.  Make sure to create a new destination or clear
 // it before calling .Scan(&dest).
 func (rows *Rows) Scan(dest interface{}) error {
+	if isNullDatum(rows.current) {
+		return ErrNullResult{}
+	}
 	return datumUnmarshal(rows.current, dest)
 }
 


### PR DESCRIPTION
```
type Data struct {
  foo int
}

v := Data{}
r.Table("table").Get("doesnotexist").Run(session).One(&v)
```

nothing tells me if the row exists or not

Wouldn't it be better for One (+ Scan) to return an error in this case ?

```
err := r.Table("table").Get("doesnotexist").Run(session).One(&v)
if _, ok := err.(ErrNullResult); ok {
  // was not found, do something
}
```

```
rows := r.Table("table").Get("doesnotexist").Run(session)
rows.Next()
```

returns true, even if there is nothing in the DB
one would expect to get false
