### PR TITLE
DeleteAt requires a start and end index.

### DIFF
--- a/query.go
+++ b/query.go
@@ -1812,7 +1812,7 @@ func (e Exp) SpliceAt(index, value interface{}) Exp {
 }
 
 // DeleteAt removes an element from an array from the given start index to the
-// end index. End index is optional, if not provided DeleteAt will only delete
+// end index. If end index is set to nil DeleteAt will only delete
 // the element at start index.
 //
 // Example usage:
@@ -1823,11 +1823,11 @@ func (e Exp) SpliceAt(index, value interface{}) Exp {
 // Example response:
 //
 //  ["a"]
-func (e Exp) DeleteAt(startIndex interface{}, endIndex interface{}) Exp {
-	if endIndex != nil {
-		return naryOperator(deleteAtKind, e, startIndex, endIndex)
+func (e Exp) DeleteAt(startIndex, endIndex interface{}) Exp {
+	if endIndex == nil {
+		return naryOperator(deleteAtKind, e, startIndex)
 	}
-	return naryOperator(deleteAtKind, e, startIndex)
+	return naryOperator(deleteAtKind, e, startIndex, endIndex)
 }
 
 // ChangeAt replaces an element of an array at a given index.

--- a/query.go
+++ b/query.go
@@ -1812,18 +1812,19 @@ func (e Exp) SpliceAt(index, value interface{}) Exp {
 }
 
 // DeleteAt removes an element from an array from the given start index to the
-// end index.
+// end index. End index is optional, if not provided DeleteAt will only delete
+// the element at start index.
 //
 // Example usage:
 //
 //  var response []string
-//  r.Expr(r.List{"a", "b", "c"}).DeleteAt(1, 1).Run(session).One(&response)
+//  r.Expr(r.List{"a", "b", "c"}).DeleteAt(1, 2).Run(session).One(&response)
 //
 // Example response:
 //
-//  ["a", "c"]
-func (e Exp) DeleteAt(startIndex, endIndex interface{}) Exp {
-	return naryOperator(deleteAtKind, e, startIndex, endIndex)
+//  ["a"]
+func (e Exp) DeleteAt(indexes ...interface{}) Exp {
+	return naryOperator(deleteAtKind, e, indexes)
 }
 
 // ChangeAt replaces an element of an array at a given index.

--- a/query.go
+++ b/query.go
@@ -1823,8 +1823,8 @@ func (e Exp) SpliceAt(index, value interface{}) Exp {
 // Example response:
 //
 //  ["a"]
-func (e Exp) DeleteAt(indexes ...interface{}) Exp {
-	return naryOperator(deleteAtKind, e, indexes)
+func (e Exp) DeleteAt(startIndex interface{}, endIndex ...interface{}) Exp {
+	return naryOperator(deleteAtKind, e, startIndex, endIndex)
 }
 
 // ChangeAt replaces an element of an array at a given index.

--- a/query.go
+++ b/query.go
@@ -1823,8 +1823,11 @@ func (e Exp) SpliceAt(index, value interface{}) Exp {
 // Example response:
 //
 //  ["a"]
-func (e Exp) DeleteAt(startIndex interface{}, endIndex ...interface{}) Exp {
-	return naryOperator(deleteAtKind, e, startIndex, endIndex)
+func (e Exp) DeleteAt(startIndex interface{}, endIndex interface{}) Exp {
+	if endIndex != nil {
+		return naryOperator(deleteAtKind, e, startIndex, endIndex)
+	}
+	return naryOperator(deleteAtKind, e, startIndex)
 }
 
 // ChangeAt replaces an element of an array at a given index.


### PR DESCRIPTION
Go doesn't support "optional" parameters so I can see why DeleteAt was written the way it was. I've added a simple if to check whether or not end index is nil. 

This helps reduce the amount of repeat code I have to write to get index values at runtime.

What I had before

```
err = r.Table(usersTable).Get(userId).Update(
        r.Map{
            "drops": r.Row.Attr("drops").DeleteAt(
                r.Row.Attr("drops").IndexesOf(query).Nth(0), // Start position of drop to delete.
                r.Row.Attr("drops").IndexesOf(query).Nth(0)) // End position of drop to delete.   DUPLICATE
            }).Run(session).One(&response)
```

What I have now

```
err = r.Table(usersTable).Get(userId).Update(
        r.Map{
            "drops": r.Row.Attr("drops").DeleteAt(
                r.Row.Attr("drops").IndexesOf(query).Nth(0), // Start position of drop to delete.
                nil,
            }).Run(session).One(&response)
```

Thoughts?
