### PR TITLE
Removed logging from getAll queries.

### DIFF
--- a/protobuf.go
+++ b/protobuf.go
@@ -138,7 +138,6 @@ func (ctx context) toTerm(o interface{}) *p.Term {
 		termType = p.Term_GET_ALL
 		options["index"] = arguments[len(arguments)-1]
 		arguments = arguments[:len(arguments)-1]
-		fmt.Println("arguments:", arguments)
 
 	case funcKind:
 		return ctx.toFuncTerm(arguments[0], arguments[1].(int))


### PR DESCRIPTION
Was causing very verbose output when doing large sets of queries. If it's not an error logging should be in the hands of the user. Thoughts?
