### PR TITLE
Introduced Runner API for cleaner client embedding

### DIFF
--- a/session.go
+++ b/session.go
@@ -8,6 +8,11 @@ import (
 	"time"
 )
 
+
+type Runner interface {
+	Run(query Exp) *Rows
+}
+
 // Session represents a connection to a server, use it to run queries against a
 // database, with either sess.Run(query) or query.Run(session).  Do not share a
 // session between goroutines, create a new one for each goroutine.
@@ -180,6 +185,6 @@ func (s *Session) getContext() context {
 
 // Run runs a query using the given session, there is one Run()
 // method for each type of query.
-func (e Exp) Run(session *Session) *Rows {
-	return session.Run(e)
+func (e Exp) Run(runner Runner) *Rows {
+	return runner.Run(e)
 }


### PR DESCRIPTION
Introduced Runner interface which exposes a single method: Run(query Exp) *Rows. Exp.Run

now expects a Runner rather than a concrete *Session).

The purpose is to allow clients to cleanly embed Session (say to provide connection pooling):

type WrappedSession struct {
   *rethinkgo.Session
}

Without the interface, you'd need to use `wrapper.Session` everywhere. With it, you can simply use `wrapper`.
